### PR TITLE
Added a check before the embed message

### DIFF
--- a/main.py
+++ b/main.py
@@ -113,7 +113,10 @@ async def on_raw_reaction_add(payload):
     # Sending an embedded message that looks nice and prepending the icon, name of message author 
     # and appending the name of the user that requested the trasnlaion
     # Clicking on author's name will jump to the translated message
-    embed = discord.Embed(title=translation.text, color=discord.Colour.random(), type="rich")
+    if len(translation.text) > 256:
+        embed = discord.Embed(title="", description=translation.text, color=discord.Colour.random(), type="rich")
+    else:
+        embed = discord.Embed(title=translation.text, color=discord.Colour.random(), type="rich")
     embed.set_author(name=message_obj.author.display_name, url=message_obj.jump_url ,icon_url=message_obj.author.display_avatar.url)
     embed.set_footer(text="Requested by " + display_name)
     # Sending the message


### PR DESCRIPTION
The title of an embed message only accepts 256 characters. So if a message length exceeds 256 chars, the translation text will be sent as the embed description instead of title.  The only difference between title and description for our purpose if that the title appears bold while the description doesn't